### PR TITLE
Use rule_action_override on aws_wafv2_web_acl

### DIFF
--- a/_test/main.tf
+++ b/_test/main.tf
@@ -30,11 +30,19 @@ resource "aws_wafv2_web_acl" "example" {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "SizeRestrictions_QUERYSTRING"
         }
 
-        excluded_rule {
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
           name = "NoUserAgent_HEADER"
         }
 

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -31,19 +31,19 @@ resource "aws_wafv2_web_acl" "example" {
         vendor_name = "AWS"
 
         rule_action_override {
+          name = "SizeRestrictions_QUERYSTRING"
+
           action_to_use {
             count {}
           }
-
-          name = "SizeRestrictions_QUERYSTRING"
         }
 
         rule_action_override {
+          name = "NoUserAgent_HEADER"
+
           action_to_use {
             count {}
           }
-
-          name = "NoUserAgent_HEADER"
         }
 
         scope_down_statement {


### PR DESCRIPTION
The attribute excluded_rule for aws_wafv2_web_acl is deprecated. Therefore replacing with `rule_action_override`